### PR TITLE
Revert "IMS-VT: Low battery handling for Video calls"

### DIFF
--- a/ims/src/org/codeaurora/ims/utils/QtiImsExtUtils.java
+++ b/ims/src/org/codeaurora/ims/utils/QtiImsExtUtils.java
@@ -432,6 +432,11 @@ public class QtiImsExtUtils {
                 carrierConfig);
     }
 
+    //TODO not removing this deprecated API to avoid compilation errors.
+    public static boolean allowVideoCallsInLowBattery(Context context) {
+        return allowVideoCallsInLowBattery(QtiCallConstants.INVALID_PHONE_ID, context);
+    }
+
     public static boolean allowVideoCallsInLowBattery(int phoneId, Context context) {
         return isCarrierConfigEnabled(phoneId, context,
                 QtiCarrierConfigs.ALLOW_VIDEO_CALL_IN_LOW_BATTERY);


### PR DESCRIPTION
* Allow old CAF and Pixel2s ims.apk to work

This reverts commit 6d5b450784f67273205430bdddd92aa7b585de75

Change-Id: I79a50016c6fea35da059a71022724d339a9bf2ee
Signed-off-by: Amitava Mitra <mitraamitava7@gmail.com>